### PR TITLE
Removed bots ability to remove triage user

### DIFF
--- a/wxt_cidrbot/git_webhook_handler.py
+++ b/wxt_cidrbot/git_webhook_handler.py
@@ -198,10 +198,10 @@ class gitwebhook:
                 reply_message = self.git_handle.git_assign(repo_name, issue_num, user_to_assign, 'assign', full_name)
                 self.logging.debug("assigning result %s", reply_message)
                 if 'Error: **invalid user**' in reply_message:
-                    self.logging.debug("Invalid user, cannot assign %s: removing from triage list", user_to_assign)
-                    self.dynamo.remove_triage_user(user_to_assign, room_id)
-                    remove_triage_message = f"{user_to_assign} cannot be assigned because they do not have access to the repo/org, removing user from triage list"
-                    self.Api.messages.create(room_id, markdown=remove_triage_message, parentId=msg_edit_id)
+                    self.logging.debug("Invalid user, cannot assign %s: ", user_to_assign)
+                    #self.dynamo.remove_triage_user(user_to_assign, room_id)
+                    fail_triage_message = f"{user_to_assign} cannot be assigned because they do not have access to the repo/org, checking next user in triage list..."
+                    self.Api.messages.create(room_id, markdown=fail_triage_message, parentId=msg_edit_id)
                     continue
                 break
         self.Api.messages.create(room_id, markdown=reply_message, parentId=msg_edit_id)


### PR DESCRIPTION
Bot no longer removes triage user when they cannot be assigned to
an issue/pr